### PR TITLE
Separation of tests in sessions

### DIFF
--- a/session/templatetags/session_filters.py
+++ b/session/templatetags/session_filters.py
@@ -79,3 +79,8 @@ def highlight(text):
 
     code = pygments.highlight(text, lexer(), formatter())
     return mark_safe(code)
+
+
+@register.filter
+def extract_url(string):
+    return string.split(" ")[1]

--- a/session/templatetags/session_tags.py
+++ b/session/templatetags/session_tags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django import template
+from session.templatetags.session_filters import label_step, extract_label
 
 
 register = template.Library()
@@ -28,3 +29,20 @@ def show_modal_window(step):
 @register.inclusion_tag('session/session_log_steps.html')
 def show_session_log_steps(log_steps):
     return {'log_steps': log_steps}
+
+
+@register.assignment_tag
+def groupify(log_steps):
+    steps_groups = {}
+    current_label = 0
+
+    for step in log_steps:
+        if label_step(step.control_line) == 'label':
+            current_label += 1
+
+        if not steps_groups.get(current_label, None):
+            steps_groups[current_label] = []
+
+        steps_groups[current_label].append(step)
+
+    return steps_groups

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -133,7 +133,6 @@ body {
 	display: block;
 	width: auto;
 	border-bottom: 1px solid black;
-	padding: 5px;
 }
 
 .log_steps .log_step .expand:hover {
@@ -146,6 +145,42 @@ body {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+
+.group_log_step {
+    display: inline-block;
+}
+
+.log_step.label_group a {
+    text-decoration: none;
+}
+
+.log_step.label_group a {
+    text-decoration: none;
+    color: #000;
+}
+
+.log_step.label_group a:focus {
+        color: #000;
+    }
+
+.log_step.label_group a:hover {
+        color: #000;
+    }
+
+.log_step .glyphicon:hover {
+	background-color: #404040;
+	color: white;
+}
+
+.log_step .glyphicon.glyphicon-ok {
+	color: #00A000;
+}
+
+.log_step.label_group h4 {
+	margin: 0;
+    padding: 10px 0 10px 5px;
+}
+
 
 .log_steps .log_step_column.log_request {
 	width: 30%;
@@ -244,4 +279,35 @@ body {
 
 .photor-close span:hover {
     opacity: .5;
+}
+
+.group {
+    background-color: #fff;
+    color: #000;
+}
+
+.group._disabled {
+    display: none;
+}
+
+._visible_group{
+    background-color: #000;
+}
+
+._visible_group .group_log_step{
+    color: #fff;
+}
+
+.expand_all_button {
+    padding: 0 0 0 5px;
+}
+
+.expand_all_button .btn-default:focus {
+    background-color: #fff;
+    border-color: #adadad;
+}
+
+._active {
+    background-color: #e6e6e6 !important;
+    border-color: #adadad !important;
 }

--- a/static/js/session.js
+++ b/static/js/session.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
 
     function open_step(id) {
         var step = $('#' + id);
-        $('.expand .glyphicon', step).toggleClass('glyphicon-chevron-down glyphicon-chevron-right');
+        $('.expand .expandglyph.glyphicon', step).toggleClass('glyphicon-chevron-down glyphicon-chevron-right');
         var opened = step.hasClass('opened');
         if (opened) {
             $('.info', step).html("");
@@ -28,7 +28,52 @@ $(document).ready(function() {
     open_step(log_step_id);
     return false; // prevent default
     });
+
+    $(this).keydown(function(eventObject){
+        if (eventObject.which == 27)
+            photor_hide();
+    });
 });
+
+function expand_all() {
+    var label_groups = $('.label_group'),
+        button = $('.btn');
+
+    console.log(button);
+    label_groups.each(function(i, item) {
+        var item_obj = $("#" + item.id);
+        console.log(item.className + ' ' + item_obj.hasClass('_visible_group'));
+        if (!button.hasClass('_active') && !item_obj.hasClass('_visible_group')) {
+            open_group(item.id);
+        }
+        if (button.hasClass('_active') && item_obj.hasClass('_visible_group')) {
+            open_group(item.id);
+        }
+    });
+
+    if (!button.hasClass('_active')) {
+        button.addClass('_active');
+        button.text('Cвернуть все тесты');
+    } else {
+        button.removeClass('_active');
+        button.text('Развернуть все тесты');
+    }
+
+}
+
+function open_group(id) {
+        var step = $('#' + id),
+            group = $('#' + id + ' div.group');
+        $('.group_log_step.expandglyph.glyphicon', step).toggleClass('glyphicon-chevron-down glyphicon-chevron-right');
+        var opened = group.hasClass('_disabled');
+        if (opened) {
+            step.addClass('_visible_group');
+            group.removeClass('_disabled');
+        } else {
+            step.removeClass('_visible_group');
+            group.addClass('_disabled');
+        }
+    }
 
 function photor_show(start_screenshot){
     var screenshots_paths = JSON.parse(screenshots_ids),

--- a/templates/session/session_log_steps.html
+++ b/templates/session/session_log_steps.html
@@ -1,21 +1,59 @@
 {% if log_steps %}
     {% load session_filters %}
     {% load session_tags %}
-
+    {% groupify log_steps as steps_groups %}
+    {% if steps_groups|length > 1 %}
+    <div class="expand_all_button">
+        <a type="button" class="btn btn-default" href="javascript: expand_all()">Развернуть все тесты</a>
+    </div>
+    {% endif %}
     <div class="log_steps">
-    {% for step in log_steps %}
-        <div id="{{ step.id }}" class="log_step {{ step.response_status|code_status }} {{ step.control_line|label_step }}">
-            {% if step.control_line|label_step %}
-                <h4><a href="session_step/{{ step.id }}">{{ step.body|extract_label|truncate_string:80 }}</a></h4>
+    {% for group in steps_groups.items %}
+        {% if "vmmasterLabel" in group.1.0.control_line %}
+            {% for step in group.1 %}
+            {% if forloop.first %}
+            <div id="{{ step.id }}" class="log_step label_group">
+                <a href="javascript: open_group('{{step.id}}')" title="{{ step.body|extract_label }}">
+                    <h4 class="group_log_step">{{ step.body|extract_label|truncate_string:80 }}</h4>
+                </a>
+                <div class="group _disabled">
             {% else %}
-                <div class="expand log_step_column"><div class="glyphicon glyphicon-chevron-right"></div></div>
-                <a href="session_step/{{ step.id }}"><div class="log_step_column log_request">{{ step.control_line|truncate_string }}</div></a>
-                <div class="log_step_column log_body">{{ step.body|truncate_string }}</div>
-                <div class="log_step_column log_time">{{ step.total_time }} sec.</div>
-                {% show_screenshot step %}
-                <div class="info"></div>
+                <div id="{{ step.id }}" class="log_step {{ step.response_status|code_status }} {{ step.control_line|label_step }}">
+                    <div class="expand log_step_column">
+                        {% if step.control_line|extract_url == "/wd/hub/session" %}
+                        <div class="expandglyph glyphicon glyphicon-chevron-right"></div>
+                        {% endif %}
+                    </div>
+                    <a href="session_step/{{ step.id }}" title="{{ step.control_line }}"><div class="log_step_column log_request">{{ step.control_line|truncate_string }}</div></a>
+                    <div class="log_step_column log_body">{{ step.body|truncate_string }}</div>
+                    <div class="log_step_column log_time">{{ step.total_time }} sec.</div>
+                    {% show_screenshot step %}
+                    <div class="info"></div>
+                </div>
             {% endif %}
-        </div>
+            {% endfor %}
+                </div>
+            </div>
+        {% else %}
+            {% for step in group.1 %}
+            <div id="{{ step.id }}" class="log_step {{ step.response_status|code_status }} {{ step.control_line|label_step }}">
+                {% if step.control_line|label_step %}
+                    <h4><a href="session_step/{{ step.id }}" title="{{ step.body|extract_label }}">{{ step.body|extract_label|truncate_string:80 }}</a></h4>
+                {% else %}
+                    <div class="expand log_step_column">
+                        {% if step.control_line|extract_url == "/wd/hub/session" %}
+                        <div class="expandglyph glyphicon glyphicon-chevron-right"></div>
+                        {% endif %}
+                    </div>
+                    <a href="session_step/{{ step.id }}" title="{{ step.control_line }}"><div class="log_step_column log_request">{{ step.control_line|truncate_string }}</div></a>
+                    <div class="log_step_column log_body">{{ step.body|truncate_string }}</div>
+                    <div class="log_step_column log_time">{{ step.total_time }} sec.</div>
+                    {% show_screenshot step %}
+                    <div class="info"></div>
+                {% endif %}
+            </div>
+            {% endfor %}
+        {% endif %}
     {% endfor %}
     </div>
     {% show_modal_window log_steps %}


### PR DESCRIPTION
Если находим на странице с шагами сессии label, то схлопываем вcе шаги после label в одну строку, которую можно разернуть, чтобы увидеть шаги.
Если label'ов нет, то поведение как раньше.

Плюс улучшения по верстке, иконки для успешных и не очень шагов, кнопка "развернуть все тесты", т.е. развернуть все label'ы с шагами.
